### PR TITLE
I/O Improvement

### DIFF
--- a/RAM Cleaner/RAM Cleaner.cpp
+++ b/RAM Cleaner/RAM Cleaner.cpp
@@ -1,13 +1,12 @@
 #include <iostream>
 #include <windows.h>
-#include <tchar.h>
 #include <psapi.h>
 #include <chrono>
-#include <conio.h>
+#include <cstdint>
 
 void SetWorkingSet(DWORD processID)
 {
-    TCHAR szProcessName[MAX_PATH] = TEXT("<unknown>");
+    char szProcessName[MAX_PATH] = "<unknown>";
 
     HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | 
         PROCESS_VM_READ | PROCESS_SET_LIMITED_INFORMATION | PROCESS_SET_QUOTA,
@@ -22,41 +21,41 @@ void SetWorkingSet(DWORD processID)
             &cbNeeded))
         {
             GetModuleBaseName(hProcess, hMod, szProcessName,
-                sizeof(szProcessName) / sizeof(TCHAR));
+                sizeof(szProcessName) / sizeof(char));
         }
-        int working = SetProcessWorkingSetSize(hProcess, -1, -1);
+        int working = SetProcessWorkingSetSize(hProcess, SIZE_MAX, SIZE_MAX);
         if (working != 1) {
-            _tprintf(TEXT("Failed\t: %s  (PID: %u)\n"), szProcessName, processID);
+            std::cout << "Failed\t: " << szProcessName << "  (PID: " << processID << ')' << std::endl;
             CloseHandle(hProcess);
             return;
         }
         CloseHandle(hProcess);
     }
-
-    _tprintf(TEXT("Success\t: %s  (PID: %u)\n"), szProcessName, processID);
+    std::cout << "Success\t: " << szProcessName << "  (PID: " << processID << ')' << std::endl;
+   
 }
 
 int main()
 {
+    std::ios_base::sync_with_stdio(false);
     std::cout << "Created by Roland Vincent\n";
     std::cout << "C++ Application\n\n";
-    std::cout << "[] Starting RAM Cleaner\n";
+    std::cout << "[] Starting RAM Cleaner" << std::endl;
     std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
 
     DWORD aProcesses[1024], cbNeeded, cProcesses;
-    unsigned int i;
 
     if (!EnumProcesses(aProcesses, sizeof(aProcesses), &cbNeeded))
         return 1;
 
     cProcesses = cbNeeded / sizeof(DWORD);
 
-    for (i = 0; i < cProcesses; i++)
+    for (DWORD i = 0; i < cProcesses; i++)
         if (aProcesses[i] != 0)
             SetWorkingSet(aProcesses[i]);
 
     std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
-    std::cout << "[] Finished in " << std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count() << " ms\n";
-    std::cout << "[Press any key to continue]"; _getch();
+    std::cout << "[] Finished in " << std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count() << " ms" << std::endl;
+    std::cout << "[Press any key to continue]"; std::cin.get();
     return 0;
 }


### PR DESCRIPTION
Mixing C++ stream (iostream) with C stream is bad idea, it's slow and can create various problem. Change into iostream function though is bad for formatting.

TCHAR is not recommend to use https://devblogs.microsoft.com/premier-developer/why-you-should-never-use-tchar-in-c-header-files/ https://stackoverflow.com/questions/234365/is-tchar-still-relevant. Since we're not using hitty pitty unicode, we can safely disable support for it.

 Change -1 it into SIZE_MAX for better readibility.

Some of newline characters is changed into std::endl manipulator as C stdio is newline buffered, but C++ iostream is fully buffered and will not flushed if encounter newline. std::endl is simply '\n' << std::flush.

conio.h is jurrasic ages era header, nobody use it on modern project. Removing conio and change _getch() into cin.get().